### PR TITLE
Updating compat for 1.16.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.devotedmc</groupId>
     <artifactId>hiddenore-compat</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.3-SNAPSHOT</version>
     <name>HiddenOre-Compat</name>
 
     <repositories>
@@ -18,37 +18,41 @@
 		<id>spigot-repo</id>
 		<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
 	</repository>
+	<repository>
+		<id>civ-github-repo</id>
+		<url>https://raw.githubusercontent.com/CivClassic/artifacts/master/</url>
+	</repository>
     </repositories>
 
     <dependencies>
 	<dependency>
-		<groupId>org.spigotmc</groupId>
-		<artifactId>spigot-api</artifactId>
-		<version>1.12.2-R0.1-SNAPSHOT</version>
+		<groupId>com.destroystokyo.paper</groupId>
+		<artifactId>paper</artifactId>
+		<version>1.16.4-R0.1-SNAPSHOT</version>
 		<scope>provided</scope>
 	</dependency>
 	<dependency>
 		<groupId>com.github.devotedmc</groupId>
 		<artifactId>hiddenore</artifactId>
-		<version>1.4.2</version>
+		<version>1.7.1</version>
 		<scope>provided</scope>
 	</dependency>
-	<dependency>
-		<groupId>com.lishid</groupId>
-		<artifactId>orebfuscator</artifactId>
-		<version>4.3.3</version>
+	<!--<dependency>
+		<groupId>net.imprex</groupId>
+		<artifactId>orebfuscator-plugin</artifactId>
+		<version>5.1.0</version>
 		<scope>provided</scope>
-	</dependency>		
+	</dependency>-->		
 	<dependency>
 		<groupId>vg.civcraft.mc.citadel</groupId>
 		<artifactId>Citadel</artifactId>
-		<version>3.11.4</version>
+		<version>4.1.1</version>
 		<scope>provided</scope>
 	</dependency>
 	<dependency>
 		<groupId>vg.civcraft.mc.civmodcore</groupId>
 		<artifactId>CivModCore</artifactId>
-		<version>1.6.1</version>
+		<version>1.8.1</version>
 		<scope>compile</scope>
 	</dependency>
     </dependencies>
@@ -67,8 +71,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/github/devotedmc/hiddenorecompat/CitadelCompat.java
+++ b/src/main/java/com/github/devotedmc/hiddenorecompat/CitadelCompat.java
@@ -1,16 +1,11 @@
 package com.github.devotedmc.hiddenorecompat;
 
-import java.util.logging.Level;
-
-import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.ReinforcementManager;
-import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
-
+import vg.civcraft.mc.citadel.model.Reinforcement;
 import com.github.devotedmc.hiddenore.events.HiddenOreGenerateEvent;
 
 /**
@@ -29,7 +24,7 @@ public class CitadelCompat implements Listener {
 	 */
 	@EventHandler(priority=EventPriority.HIGHEST, ignoreCancelled = true)
 	public void captureHiddenOreGenerate(HiddenOreGenerateEvent hoge) {
-		ReinforcementManager rm = Citadel.getReinforcementManager();
+		ReinforcementManager rm = Citadel.getInstance().getReinforcementManager();
 		Reinforcement rein = rm.getReinforcement(hoge.getBlock());
 		if (rein != null) {
 			hoge.setCancelled(true);

--- a/src/main/java/com/github/devotedmc/hiddenorecompat/HiddenOreCompat.java
+++ b/src/main/java/com/github/devotedmc/hiddenorecompat/HiddenOreCompat.java
@@ -16,7 +16,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class HiddenOreCompat extends JavaPlugin implements Listener {
 
 	CitadelCompat citadel = null;
-	OrebfuscatorCompat orebfuscator = null;
+	//OrebfuscatorCompat orebfuscator = null;
 	
 	@Override
 	public void onEnable() {
@@ -28,12 +28,13 @@ public class HiddenOreCompat extends JavaPlugin implements Listener {
 		} else {
 			this.getLogger().log(Level.INFO, "HiddenOre-Citadel compatibility skipped.");
 		}
-		if (manager.isPluginEnabled("Orebfuscator4")) {
+		/* TODO: Orebfuscator is not exposing an interface for compat yet?
+		  if (manager.isPluginEnabled("Orebfuscator4")) {
 			this.getLogger().log(Level.INFO, "Preparing HiddenOre-Orebfuscator compatibility extender");
 			orebfuscator = new OrebfuscatorCompat();
 			manager.registerEvents(orebfuscator, this);
 		} else {
 			this.getLogger().log(Level.INFO, "HiddenOre-Orebfuscator compatibility skipped.");
-		}
+		}*/
 	}
 }

--- a/src/main/java/com/github/devotedmc/hiddenorecompat/OrebfuscatorCompat.java
+++ b/src/main/java/com/github/devotedmc/hiddenorecompat/OrebfuscatorCompat.java
@@ -9,9 +9,11 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
 import com.github.devotedmc.hiddenore.events.HiddenOreEvent;
-import com.lishid.orebfuscator.obfuscation.BlockUpdate;
+//import com.lishid.orebfuscator.obfuscation.BlockUpdate;
 
 /**
+ * TODO latest Orebfuscator does not appear to expose an equiv notification option. 
+ * 
  * Handles the standard hiddenore break event, and triggers an orebfuscator
  * update when one is called.
  * 
@@ -24,8 +26,8 @@ public class OrebfuscatorCompat implements Listener {
 	 */
 	@EventHandler(priority=EventPriority.HIGHEST, ignoreCancelled=true)
 	public void captureHiddenOreBreak(HiddenOreEvent hoe) {
-		List<Location> L= new ArrayList<Location>(1);
+		/*List<Location> L= new ArrayList<Location>(1);
 		L.add(hoe.getDropLocation());
-		BlockUpdate.updateByLocations(L, 1);
+		BlockUpdate.updateByLocations(L, 1);*/
 	}
 }


### PR DESCRIPTION
Orebfuscator no longer appears to have an interface to "notify" of an update needed, so temporarily disabled.

Citadel compatibility remains. Updated to latest.